### PR TITLE
Fixed a bug that caused the read thread to exit prematurely.

### DIFF
--- a/TMQTTClient/MQTT.pas
+++ b/TMQTTClient/MQTT.pas
@@ -266,7 +266,7 @@ type
           if SocketWrite(Data) then
             begin
               Result := True;
-              FReadThread.Terminate;
+              FReadThread.waitFor;
               FSocket.CloseSocket;
               FisConnected := False;
               FSocket.Free;

--- a/TMQTTClient/MQTTReadThread.pas
+++ b/TMQTTClient/MQTTReadThread.pas
@@ -308,6 +308,12 @@ type TRxStates = (RX_START, RX_FIXED_HEADER, RX_LENGTH, RX_DATA, RX_ERROR);
     begin
       Result := False;
       // Returns whether the Data was successfully written to the socket.
+
+      while not FPSocket^.CanWrite(0) do
+      begin
+        sleep(100);
+      end;
+
       sentData := FPSocket^.SendBuffer(Pointer(Data), Length(Data));
       if sentData = Length(Data) then
         Result := True


### PR DESCRIPTION
In the function TMQTTReadThread.SocketWrite, the data is passed to the socket instance immediately, the socket is sometimes not ready for this, particularly when the thread first starts and the client is trying to send the CONNECT command. The socket doesn't write any bytes and so the FPSocket^.SendBuffer function returns 0. This is then checked against the number of bytes going in and found to be different and so the worst is assumed and the thread stops as it thinks there is an error.

My quick solution is to have the SocketWrite function wait for the socket to be capable of writing before sending anything. The code I have added checks to see if the socket is writable every 100ms until it is. (It will execute immediately if the socket is already ready as it is a 'while' loop and not a 'repeat until'.)

I don't know if this will cause problems such as hanging if a socket is genuinely permanently unwritable. A timeout may need to be implemented if this is the case.

Commit message: "Added code to wait for the connection to be usable before sending any data (This stopped my read thread from exiting without doing anything all the time)"

DanielJABailey.
