### PR TITLE
Bugs fix (memory leak, access violation, hang (dead lock)) and new feature (retain)

### DIFF
--- a/TMQTTClient/MQTT.pas
+++ b/TMQTTClient/MQTT.pas
@@ -492,6 +492,12 @@ type
 
         destructor TMQTTClient.Destroy;
         begin
+          if isConnected then
+          begin
+            FReadThread.Terminate;
+            FReadThread.WaitFor;
+            //ForceDisconnect;
+          end;
           FSocket.free;
           FMessageQueue.free;
           FMessageAckQueue.free;

--- a/TMQTTClient/MQTT.pas
+++ b/TMQTTClient/MQTT.pas
@@ -492,13 +492,14 @@ type
 
         destructor TMQTTClient.Destroy;
         begin
-          if isConnected then
+          if (isConnected) and (FReadThread <> nil) then
           begin
             FReadThread.Terminate;
             FReadThread.WaitFor;
-            //ForceDisconnect;
+            //note: free is not needed - the FreeOnTerminate mode is enabled
           end;
-          FSocket.free;
+          if FSocket <> nil then
+            FreeAndNil(FSocket);
           FMessageQueue.free;
           FMessageAckQueue.free;
           DoneCriticalSection(FCritical);

--- a/TMQTTClient/MQTT.pas
+++ b/TMQTTClient/MQTT.pas
@@ -599,12 +599,22 @@ type
 
         function VariableHeaderConnect(KeepAlive: Word): TBytes;
 
-        const 
+        const
+          //todo: version update! MQIsdp->MQTT. version 4!
           MQTT_PROTOCOL = 'MQIsdp';
           MQTT_VERSION = 3;
 
         var 
           Qos, Retain: word;
+{todo: connect flags
+7 User Name Flag
+6 Password Flag
+5 Will Retain
+4 Will QoS
+3 Will QoS
+2 Will Flag
+1 Clean Session
+0 Reserved }
           iByteIndex: integer;
           ProtoBytes: TUTF8Text;
         begin

--- a/TMQTTClient/MQTT.pas
+++ b/TMQTTClient/MQTT.pas
@@ -62,16 +62,21 @@ type
                      );
 
   // The message class definition
+
+  { TMQTTMessage }
+
   TMQTTMessage = class
     private 
       FTopic   : ansistring;
       FPayload : ansistring;
+      FRetain  : boolean;
 
     public 
       property Topic   : ansistring read FTopic;
       property PayLoad : ansistring read FPayload;
+      property Retain  : boolean read FRetain;
 
-      constructor Create(const topic_ : ansistring; const payload_ : ansistring);
+      constructor Create(const topic_ : ansistring; const payload_ : ansistring; const retain_: boolean);
     end;
 
     // The acknowledgement class definition
@@ -193,11 +198,13 @@ type
 
         implementation
 
-        constructor TMQTTMessage.Create(const Topic_ : ansistring; const Payload_ : ansistring);
+                                constructor TMQTTMessage.Create(const topic_: ansistring;
+                  const payload_: ansistring; const retain_: boolean);
         begin
           // Save the passed parameters
           FTopic   := Topic_;
           FPayload := Payload_;
+          FRetain   := retain_;
         end;
 
         constructor TMQTTMessageAck.Create(const messageType_ : TMQTTMessageType;
@@ -743,7 +750,7 @@ type
             // Protected code.  
             EnterCriticalSection (FCritical);
             try
-              FMessageQueue.Push (TMQTTMessage.Create(topic, payload));
+              FMessageQueue.Push (TMQTTMessage.Create(topic, payload, retain));
             finally
               LeaveCriticalSection (FCritical);
             end;

--- a/TMQTTClient/MQTTReadThread.pas
+++ b/TMQTTClient/MQTTReadThread.pas
@@ -161,7 +161,7 @@ type TRxStates = (RX_START, RX_FIXED_HEADER, RX_LENGTH, RX_DATA, RX_ERROR);
                         //sleep(1);
 
                         // Send CONNECT message
-                        while true do
+                        while not self.Terminated do
                         begin
                           writeln('loop...');
                           SocketWrite(Data);


### PR DESCRIPTION
Bugs fixed:
When the program runs for several days it happens to hang (when reconnecting procedure).
When the program runs for several days, a memory leak occurs.

Detailed list:
new feature (break compatible!): support "retain" flag in TPublishEvent (OnPublish).
bug fix: mem leak.
bug fix: potential infinity loop.
bug fix: Hang on call "Dissconect" (one hangup for ~50-100 disconnects) ([more]( https://github.com/ZiCog/mqtt-free-pascal/pull/1/commits/07f7b6df9555930d46e5ddb4037093bda0e3bec6#r138469285)).
bug fix: AV then thread terminating but socket already free in TMQTTClient.
change Socket owner - move from TMQTTClient to TMQTTReadThread.
remove strange "PTCPBlockSocket = ^TTCPBlockSocket" (because the class is already pointer)
change "SocketWrite" - remove duplicate code in TMQTTClient.
TMQTTReadThread.Execute add "try-finally".
TMQTTClient.OnRTTerminate add "FReadThread := nil" and "FisConnected := false".
"function FixedHeader" - remove mathematics, add boolean function.
